### PR TITLE
Fixed empty()

### DIFF
--- a/proposed/PSR/Cache/Pool.php
+++ b/proposed/PSR/Cache/Pool.php
@@ -35,6 +35,6 @@ interface Pool
      *
      * @return bool
      */
-    function empty();
+    function flush();
 
 }


### PR DESCRIPTION
I'd prefer invalidate(), personally, but we should use at least flush() since already documented. :)
