### PR TITLE
Clarification on Item::set()

### DIFF
--- a/proposed/PSR/Cache/Extensions/TaggableItem.php
+++ b/proposed/PSR/Cache/Extensions/TaggableItem.php
@@ -17,7 +17,7 @@ interface TaggableItem extends \PSR\Cache\Item
      * Accepts an array of strings for the item to be tagged with. The tags
      * passed should overwrite any existing tags, and passing an empty array
      * will cause all tags to be removed. Changes to an Item's tags are not
-     * guaranteed to persist unless the "set" function is called.
+     * guaranteed to persist unless Item::set() method is called.
      *
      * @param array $tags
      * @return void

--- a/proposed/PSR/Cache/Item.php
+++ b/proposed/PSR/Cache/Item.php
@@ -1,3 +1,5 @@
+<?php
+
 namespace PSR\Cache;
 
 /**

--- a/proposed/PSR/Cache/Pool.php
+++ b/proposed/PSR/Cache/Pool.php
@@ -1,3 +1,5 @@
+<?php
+
 namespace PSR\Cache;
 
 /**


### PR DESCRIPTION
Clarification on Item::set() as the method binding to the underlying system.

Added php tags.
