### PR TITLE
Add isHit and isMiss to CacheItem in place of isValid

### DIFF
--- a/proposed/PSR-Cache.md
+++ b/proposed/PSR-Cache.md
@@ -239,7 +239,7 @@ interface Item
      *
      * An item is considered a hit when it exists and has not passed its
      * expiration. Implementing Library can define additional conditions
-     * that may result in an existing cache item not be considered a hit.
+     * that may result in an existing cache item not being considered a hit.
      *
      * @return bool
      */

--- a/proposed/PSR-Cache.md
+++ b/proposed/PSR-Cache.md
@@ -225,15 +225,25 @@ interface Item
     function set($value, $ttl = null);
 
     /**
-     * Validates the current state of the item in the cache.
+     * The current state of the item represents a "cache miss."
      *
-     * Checks the validity of a cache result. If the object is good (is not a 
-     * miss, and meets all the standards set by the Implementing Library) then
-     * this function returns true.
+     * An item is considered a miss when it does not exist or has passed its
+     * expiration. Implementing Library can define additional miss conditions.
      *
      * @return bool
      */
-    function isValid();
+    function isMiss();
+
+    /**
+     * The current state of the item represents a "cache hit."
+     *
+     * An item is considered a hit when it exists and has not passed its
+     * expiration. Implementing Library can define additional conditions
+     * that may result in an existing cache item not be considered a hit.
+     *
+     * @return bool
+     */
+    function isHit();
 
     /**
      * Removes the current key from the cache.


### PR DESCRIPTION
Renamed `isValid` to `isHit` as discussed on IRC. The concept of cache validity is a separate concern and we should not overload the meaning here.

Added `isMiss` as syntactic sugar for `!$item->isHit()`.

There were apparently some mailing list concerns about `isMiss` looking like a double negative (or something; I didn't quite follow at the time and can't find the argument now). However, there are two states represented by this cache system, a "cache hit" and a "cache miss." People will build workflows around both concepts. Forcing one camp over the other to negate with `!` seems unfriendly when we can add this sugar.

_I'm open to removing `isMiss` if it is going to be a problem, I just thought I'd save some time and add it here now as I was already in the process of editing._
## Use case for `isMiss` workflow:

This is more for inline operations where you are getting something from cache locally and then trying to do something with it locally rather than returning the cached result. In this case, you care if there is a cache miss because in that case you need to get and then set the value before moving on to the rest of the operation.

``` php
<?php
function do_something_with_foo()
{
    $item = $pool->getItem('foo');

    $foo = $item->get();

    if ($item->isMiss()) {
        $foo = expensive_operation();
        $item->set($foo, 300);
    }

    // do something with a valid $foo
}
```
## Use case for `isHit` workflow:

This is useful for a "return early" workflow where you want to just return right away if something was found in the cache.

``` php
<?php
function get_foo()
{
    $item = $pool->getItem('foo');

    if ($item->isHit()) {
        return $item->get();
    }

    $foo = expensive_operation();
    $item->set($foo, 300);

    return $foo;
}
```
## Negate

Sure, we can use `!` but either one camp or the other is going to be unhappy. Why choose when we can easily do both? :)
