### PR TITLE
Update PSR-Cache.md

### DIFF
--- a/proposed/PSR-Cache.md
+++ b/proposed/PSR-Cache.md
@@ -118,6 +118,9 @@ namespace PSR\Cache;
  */
 interface Pool
 {
+
+    protected $prefix;
+
     /**
      * Returns objects which implement the Cache\Item interface.
      *


### PR DESCRIPTION
Suppose you have a Drupal plugin that uses PSR-Cache and is configured to use, say, APC.

Then you add, say, a Symfony app that also uses APC.

There are bound to be key collisions here.

I would propose a "prefix" property and a composeKey ($key) { return $this->prefix . $key; }

This would allow each app to have their own configurable prefix providing a namespace.

It still doesn't guarantee two children won't use the same prefix . $key, but at least it gives the developers a sensible way out of the dilemma.

Frameworks could have standards to reduce the probability of collision. Ex, Drupal could standardize on 'Drupal_Modulename_site' as the default.

The 'site' part covers multisite.
